### PR TITLE
Tidy test running and use travis in elm mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,4 @@
-sudo: false
-
-cache:
-  directories:
-    - test/elm-stuff/build-artifacts
-    - sysconfcpus
-
-language: node_js
-
-node_js:
-  - "4.3"
-
-before_install:
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];
-    then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
-    fi
-  - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-  - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
-    if [ ! -d sysconfcpus/bin ];
-    then
-      git clone https://github.com/obmarg/libsysconfcpus.git;
-      cd libsysconfcpus;
-      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
-      make && make install;
-      cd ..;
-    fi
-
-install:
-  - npm install -g elm@0.18 elm-test
-  - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
-  - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
-  - chmod +x $(npm config get prefix)/bin/elm-make
+language: elm
 
 script:
   - bash tests/run-tests.sh

--- a/tests/elm.json
+++ b/tests/elm.json
@@ -1,8 +1,6 @@
 {
     "type": "application",
-    "source-directories": [
-        "src"
-    ],
+    "source-directories": [],
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -5,8 +5,7 @@ set -o nounset;
 
 #let the caller supply an ELM_TEST binary if desired
 if [ ! -v ELM_TEST ]; then
-    npm install elm-test;
-    ELM_TEST=node_modules/elm-test/bin/elm-test;
+    ELM_TEST=elm-test;
 fi
 
 # since elm/core is treated specially by the compiler (it's always
@@ -49,9 +48,9 @@ VERSION_DIR="$(ls ${ELM_HOME}/0.19.0/package/elm/core/)"
 CORE_PACKAGE_DIR="${ELM_HOME}/0.19.0/package/elm/core/$VERSION_DIR"
 CORE_GIT_DIR="$(dirname $PWD)"
 
-echo; 
+echo;
 echo "Linking $CORE_PACKAGE_DIR to $CORE_GIT_DIR"
-echo; 
+echo;
 rm -rf "$CORE_PACKAGE_DIR"
 ln -sv "$CORE_GIT_DIR" "$CORE_PACKAGE_DIR"
 rm -vf "${CORE_GIT_DIR}"/*.dat "${CORE_GIT_DIR}"/doc*.json


### PR DESCRIPTION
This removes `src` as a source directory in the tests directory
as it does not exist.
Additionally, it uses a global elm-test by default in `run-tests.sh`
and uses travis elm support.

Refs: https://docs.travis-ci.com/user/languages/elm
Refs: https://github.com/elm/core/pull/1017